### PR TITLE
Deactivate search controller when view disappears

### DIFF
--- a/ModalDismissIssueExample.xcodeproj/project.pbxproj
+++ b/ModalDismissIssueExample.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = YPDEV2E775;
+				DEVELOPMENT_TEAM = HQ8TLN3UQR;
 				INFOPLIST_FILE = ModalDismissIssueExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.andrewbennet.ModalDismissIssueExample;
@@ -290,7 +290,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = YPDEV2E775;
+				DEVELOPMENT_TEAM = HQ8TLN3UQR;
 				INFOPLIST_FILE = ModalDismissIssueExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.andrewbennet.ModalDismissIssueExample;

--- a/ModalDismissIssueExample/Base.lproj/Main.storyboard
+++ b/ModalDismissIssueExample/Base.lproj/Main.storyboard
@@ -82,10 +82,19 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Akl-8y-yDH">
+                                <rect key="frame" x="318" y="617" width="37" height="30"/>
+                                <state key="normal" title="Done"/>
+                                <connections>
+                                    <action selector="doneWasPressed:" destination="cUK-9D-GcR" eventType="touchUpInside" id="JOA-Rt-0gp"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="oGl-0B-84g" firstAttribute="bottom" secondItem="Akl-8y-yDH" secondAttribute="bottom" constant="20" id="17F-aB-0Qq"/>
                             <constraint firstItem="jM1-oO-6cI" firstAttribute="leading" secondItem="oGl-0B-84g" secondAttribute="leading" constant="8" id="GCw-cS-Tbb"/>
+                            <constraint firstItem="oGl-0B-84g" firstAttribute="trailing" secondItem="Akl-8y-yDH" secondAttribute="trailing" constant="20" id="Omg-hq-H8Q"/>
                             <constraint firstItem="jM1-oO-6cI" firstAttribute="top" secondItem="oGl-0B-84g" secondAttribute="top" constant="40" id="b5b-CD-0Fd"/>
                             <constraint firstItem="oGl-0B-84g" firstAttribute="bottom" secondItem="jM1-oO-6cI" secondAttribute="bottom" constant="40" id="eWK-YA-YSi"/>
                             <constraint firstItem="oGl-0B-84g" firstAttribute="trailing" secondItem="jM1-oO-6cI" secondAttribute="trailing" constant="8" id="qSF-hB-tR2"/>

--- a/ModalDismissIssueExample/ViewController.swift
+++ b/ModalDismissIssueExample/ViewController.swift
@@ -21,6 +21,11 @@ class Page1VC: UIViewController {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        navigationItem.searchController?.isActive = false
+    }
 }
 
 class Page2VC: UIViewController {

--- a/ModalDismissIssueExample/ViewController.swift
+++ b/ModalDismissIssueExample/ViewController.swift
@@ -9,11 +9,9 @@
 import UIKit
 
 class Page1VC: UIViewController {
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Set up a search controller, add it to the navigation item.
-        // When the following block is commented out, the issue upon dismissing Page2VC is not present
         
         let searchController = UISearchController(searchResultsController: nil)
         searchController.obscuresBackgroundDuringPresentation = false
@@ -22,10 +20,17 @@ class Page1VC: UIViewController {
         navigationItem.hidesSearchBarWhenScrolling = false
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         navigationItem.searchController?.isActive = false
     }
+    
+    // this is not needed, but I wanted to make sure dismiss worked from Page1VC, too
+    
+    @IBAction func doneWasPressed(_ sender: Any) {
+        navigationController!.dismiss(animated: true)
+    }
+
 }
 
 class Page2VC: UIViewController {
@@ -40,12 +45,11 @@ class Page2VC: UIViewController {
         // They both have problems!
         
         // Type 1 produces a visual artifact: a duplicate VS is seen under the dismissed one
-        self.presentingViewController!.dismiss(animated: true)
+        // presentingViewController!.dismiss(animated: true)
         
         // Type 2 needs to be called twice in order to work! Presumably, the first call is dismissing
         // the search controller?...
-        // self.navigationController!.dismiss(animated: true)
-        
+        navigationController!.dismiss(animated: true)
     }
 }
 


### PR DESCRIPTION
I noticed in the view debugger that when I was on Page2VC, the search controller was still in the view controller hierarchy. So, by adding `isActive` to `false`, that problem disappeared and the artifact when dismissing the view controller was resolved.